### PR TITLE
foo2hbpl1-wrapper: Unimplemented paper code 1 Error

### DIFF
--- a/foo2hbpl1-wrapper.in
+++ b/foo2hbpl1-wrapper.in
@@ -341,20 +341,20 @@ Custom*)
 # /usr/share/ghostscript/9.10/Resource/Init/gs_statd.ps
 # foo2hbpl1 will provide the appropriate numeric value
 
-letter)		DIM=5100x6600  ;;
-legal)		DIM=5100x8400  ;;
-a4)		DIM=4961x7016  ;;
-executive)	DIM=4350x6300  ;;
-env10)		DIM=2475x5700  ;;
-monarch)	DIM=2325x4500  ;;
-c5)		DIM=3827x5409  ;;
-envDL)		DIM=2599x5197  ;;
-isob5|b5)	DIM=4158x5906  ;;
-jisb5)		DIM=4299x6071  ;;
-a5)		DIM=3496x4961  ;;
-folio)		DIM=5100x7800  ;;
-pa4)		DIM=4961x6600  ;;
-archA)		DIM=5400x7200  ;;
+4|letter|Letter)	DIM=5100x6600  ;;
+7|legal|Legal)		DIM=5100x8400  ;;
+1|a4|A4)		DIM=4961x7016  ;;
+5|executive|Executive)	DIM=4350x6300  ;;
+9|env10|Env10)		DIM=2475x5700  ;;
+10|monarch|EnvMonarch)	DIM=2325x4500  ;;
+11|c5|EnvC5)		DIM=3827x5409  ;;
+12|envDL|EnvDL)		DIM=2599x5197  ;;
+isob5|b5)		DIM=4158x5906  ;;
+2|jisb5|B5jis)		DIM=4299x6071  ;;
+a5)			DIM=3496x4961  ;;
+6|folio|Folio)		DIM=5100x7800  ;;
+pa4)			DIM=4961x6600  ;;
+archA)			DIM=5400x7200  ;;
 *)		error "Unimplemented paper code $PAPER";;
 esac
 

--- a/foo2hbpl1-wrapper.in
+++ b/foo2hbpl1-wrapper.in
@@ -351,7 +351,7 @@ Custom*)
 12|envDL|EnvDL)		DIM=2599x5197  ;;
 isob5|b5)		DIM=4158x5906  ;;
 2|jisb5|B5jis)		DIM=4299x6071  ;;
-a5)			DIM=3496x4961  ;;
+3|a5|A5)		DIM=3496x4961  ;;
 6|folio|Folio)		DIM=5100x7800  ;;
 pa4)			DIM=4961x6600  ;;
 archA)			DIM=5400x7200  ;;

--- a/osx-hotplug/Makefile
+++ b/osx-hotplug/Makefile
@@ -64,8 +64,5 @@ clean:
 	rm -f *.o *.1
 
 uninstall:
-	( \
-		echo "g/osx-hplj-hotplug/d"; \
-		echo "w"; \
-	) | ex $(RC)
+	-(echo "g/osx-hplj-hotplug/d"; echo "w") | ex $(RC)
 	-rm -f $(BIN)/osx-hplj-hotplug


### PR DESCRIPTION
Trying to use this code to get a Dell 1660w printer working with Ubuntu 18-04LTS.  All compiled correctly, selected new available Dell 1660 in CUPS, however could not print to the printer.
Switched on CUP debugging to find the error:
foo2hbpl1-wrapper: Unimplemented paper code 1

Found article [https://www.raspberrypi.org/forums/viewtopic.php?t=73619&start=25]

It looks like the Dell-1660.ppd file sends the paper size as a parameter(-p1 for A4) and not a paper size itself (A4|a4).

Have amended foo2hbpl1-wrapper.in to interpret both paper sizes & paper parameters.  This has fixed the issue on a Dell-1660 printer and it is possible to print from an Ubuntu 18.04 LTS to a Dell 1660w Printer.
